### PR TITLE
news now called TOP_STORIES_API_URL

### DIFF
--- a/app/views/Home.js
+++ b/app/views/Home.js
@@ -645,7 +645,7 @@ var Home = React.createClass({
 	// #4 - NEWS CARD
 	fetchTopStories: function() {
 
-		fetch(AppSettings.NEWS_API_URL, {
+		fetch(AppSettings.TOP_STORIES_API_URL, {
 				headers: {
 					'Cache-Control': 'no-cache'
 				}


### PR DESCRIPTION
In the README the news app settings references TOP_STORIES_API_URL for news items, but in the app it is NEWS_API_URL.  This change will get the news feeds to work.