### PR TITLE
Modal Welcome and Special Banner Breakout

### DIFF
--- a/app/views/Home.js
+++ b/app/views/Home.js
@@ -19,6 +19,7 @@ import {
 } from 'react-native';
 
 import BannerView from './banner/BannerView';
+import InfoModal from './common/InfoModal';
 
 // Cards
 import EventCard from './events/EventCard'
@@ -208,29 +209,17 @@ var Home = React.createClass({
 			<View style={css.main_container}>
 				<ScrollView contentContainerStyle={css.scroll_main}>
 
+					
 					{this.AppSettings['0'].MODAL_ENABLED ? (
-						<Modal animationType={'none'} transparent={true} visible={this.state.modalVisible}>
-							<View style={css.modal_container}>
-								<Text style={css.modal_text_intro}>Hello.</Text>
-								<Text style={css.modal_text}>
-									Thanks for trying {AppSettings.APP_NAME}!{'\n\n'}
-									{AppSettings.APP_NAME} connects you to campus with:{'\n\n'}
-									- location-based shuttle information{'\n'}
-									- timely news and events{'\n'}
-									- nearby points of interest{'\n'}
-									- and we&apos;ll be adding new stuff all the time{'\n'}
-								</Text>
-
-								<TouchableHighlight underlayColor={'rgba(200,200,200,.5)'} onPress={ () => this.setModalVisible(false) }>
-									<View style={css.modal_button}>
-										<Text style={css.modal_button_text}>ok, let&apos;s go already</Text>
-									</View>
-								</TouchableHighlight>
-							</View>
-						</Modal>
+						<InfoModal modalVisible={this.state.modalVisible} title={'Hello.'} onPress={ () => this.setModalVisible(false) } buttonText={'ok, let\'s go already'}>
+							Thanks for trying {AppSettings.APP_NAME}!{'\n\n'}
+							{AppSettings.APP_NAME} connects you to campus with:{'\n\n'}
+							- location-based shuttle information{'\n'}
+							- timely news and events{'\n'}
+							- nearby points of interest{'\n'}
+							- and we&apos;ll be adding new stuff all the time{'\n'}
+						</InfoModal>
 					) : null }
-
-
 
 					{/* SPECIAL EVENTS CARD */}
 					{this.state.welcomeWeekEnabled ? (

--- a/app/views/Home.js
+++ b/app/views/Home.js
@@ -27,7 +27,6 @@ import WeatherCard from './weather/WeatherCard';
 
 // Node Modules
 var TimerMixin = 		require('react-timer-mixin');
-var Realm = 			require('realm');
 var MapView = 			require('react-native-maps');
 
 // App Settings / Util / CSS
@@ -217,7 +216,7 @@ var Home = React.createClass({
 
 							<View style={css.destinationcard_bot_container}>
 								<View style={css.destinationcard_map_container}>
-									
+
 									{this.state.nearbyAnnotations ? (
 
 										<MapView
@@ -592,12 +591,12 @@ var Home = React.createClass({
 			}
 
 			var newAnnotations = {};
-			
+
 			newAnnotations.coords = {
 				latitude: parseFloat(ucsd_node[i].mkrLat),
 				longitude: parseFloat(ucsd_node[i].mkrLong)
 			};
-			
+
 
 			newAnnotations.latitude = parseFloat(ucsd_node[i].mkrLat);
 			newAnnotations.longitude = parseFloat(ucsd_node[i].mkrLong);

--- a/app/views/Home.js
+++ b/app/views/Home.js
@@ -18,6 +18,8 @@ import {
 	Alert,
 } from 'react-native';
 
+import BannerView from './banner/BannerView';
+
 // Cards
 import EventCard from './events/EventCard'
 import TopStoriesCard from './topStories/TopStoriesCard';
@@ -232,9 +234,7 @@ var Home = React.createClass({
 
 					{/* SPECIAL EVENTS CARD */}
 					{this.state.welcomeWeekEnabled ? (
-						<TouchableHighlight underlayColor={'rgba(200,200,200,.1)'} onPress={ () => this.gotoWebView('Welcome Week', AppSettings.WELCOME_WEEK_URL) }>
-							<Image style={[css.card_plain, css.card_special_events]} source={ require('../assets/img/welcome_week.jpg') } />
-						</TouchableHighlight>
+						<BannerView navigator={this.props.navigator} site={{ title: 'Welcome Week', url: AppSettings.WELCOME_WEEK_URL }} bannerImage={require('../assets/img/welcome_week.jpg')} />
 					) : null }
 
 
@@ -849,10 +849,6 @@ var Home = React.createClass({
 
 		destinationData.distLatLon = Math.sqrt(Math.pow(Math.abs(this.getCurrentPosition('lat') - destinationData.mkrLat), 2) + Math.pow(Math.abs(this.getCurrentPosition('lon') - destinationData.mkrLong), 2));
 		this.props.navigator.push({ id: 'DestinationDetail', component: DestinationDetail, title: destinationData.title, destinationData: destinationData });
-	},
-
-	gotoWebView: function(title, url) {
-		this.props.navigator.push({ id: 'WebWrapper', component: WebWrapper, title: title, webViewURL: url });
 	},
 
 	gotoFeedbackForm: function() {

--- a/app/views/WelcomeModal.js
+++ b/app/views/WelcomeModal.js
@@ -1,0 +1,54 @@
+'use strict'
+
+import React from 'react'
+import {
+	View,
+	TouchableHighlight,
+  Image,
+	Text,
+  Modal
+} from 'react-native';
+
+import InfoModal from './common/InfoModal';
+
+var css =             require('../styles/css');
+var AppSettings = 		require('../AppSettings');
+
+import realm from './realm';
+
+// Handles showing a welcome modal to first time visitors
+export default class WelcomeModal extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      modalVisible: true
+    };
+  }
+  componentWillMount() {
+    this.SavedAppSettings = realm.objects('AppSettings');
+
+    // Hide welcome modal if previously dismissed
+		if (this.SavedAppSettings[0].MODAL_ENABLED === false) {
+			this.setState({ modalVisible: false });
+		}
+  }
+  setModalVisible = (visible) => {
+  	realm.write(() => {
+			realm.create('AppSettings', { id: 1, MODAL_ENABLED: visible }, true);
+		});
+		this.setState({ modalVisible: visible });
+  }
+  render() {
+    return(
+      <InfoModal modalVisible={this.state.modalVisible} title={'Hello.'} onPress={ () => this.setModalVisible(false) } buttonText={'ok, let\'s go already'}>
+        Thanks for trying {AppSettings.APP_NAME}!{'\n\n'}
+        {AppSettings.APP_NAME} connects you to campus with:{'\n\n'}
+        - location-based shuttle information{'\n'}
+        - timely news and events{'\n'}
+        - nearby points of interest{'\n'}
+        - and we&apos;ll be adding new stuff all the time{'\n'}
+      </InfoModal>
+    );
+  }
+}

--- a/app/views/banner/BannerView.js
+++ b/app/views/banner/BannerView.js
@@ -1,0 +1,26 @@
+'use strict'
+
+import React from 'react'
+import {
+	View,
+	TouchableHighlight,
+  Image,
+} from 'react-native';
+
+var WebWrapper = require('../WebWrapper');
+var css = require('../../styles/css');
+
+// Card for displaying a large banner on the top of the screen
+export default class BannerView extends React.Component {
+  gotoWebView = () => {
+    // launch website
+    this.props.navigator.push({ id: 'WebWrapper', component: WebWrapper, title: this.props.site.title, webViewURL: this.props.site.url });
+  }
+  render() {
+    return(
+      <TouchableHighlight underlayColor={'rgba(200,200,200,.1)'} onPress={this.gotoWebView}>
+        <Image style={[css.card_plain, css.card_special_events]} source={ this.props.bannerImage } />
+      </TouchableHighlight>
+    );
+  }
+}

--- a/app/views/banner/TopBannerView.js
+++ b/app/views/banner/TopBannerView.js
@@ -1,0 +1,53 @@
+'use strict'
+
+import React from 'react'
+import {
+	View,
+	TouchableHighlight,
+  Image,
+	Text,
+  Modal
+} from 'react-native';
+
+import BannerView from './BannerView';
+
+var css =             require('../../styles/css');
+var general = 			  require('../../util/general');
+var AppSettings = 		require('../../AppSettings');
+
+// Manages the top 'hero' banner & decides what if anything to show
+// Currently decides based on static dates but an API would be great for breaking info
+export default class TopBannerView extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      site: {
+        title: 'Welcome Week',
+        url: AppSettings.WELCOME_WEEK_URL
+      },
+      bannerImage: require('../../assets/img/welcome_week.jpg'),
+    };
+  }
+  render() {
+    let shouldShowWelcomeBanner = false;
+    // Check welcome week date range - Activate from Aug 1 to Sep 24
+    var currentYear = general.getTimestamp('yyyy');
+    var currentMonth = general.getTimestamp('m');
+    var currentDay = general.getTimestamp('d');
+    if ((currentYear == 2016) && ((currentMonth == 8) || (currentMonth == 9 && currentDay <= 24))) {
+      shouldShowWelcomeBanner = true;
+    }
+
+    if (!shouldShowWelcomeBanner){ // show nothing if it isn't the correct time
+      return null;
+    }
+
+    return(
+      <BannerView
+        navigator={this.props.navigator}
+        site={this.state.site}
+        bannerImage={this.state.bannerImage} />
+    );
+  }
+}

--- a/app/views/common/InfoModal.js
+++ b/app/views/common/InfoModal.js
@@ -1,0 +1,39 @@
+'use strict'
+
+import React from 'react'
+import {
+	View,
+	TouchableHighlight,
+  Image,
+	Text,
+  Modal
+} from 'react-native';
+
+var css = require('../../styles/css');
+
+// Modal with text information content and a large button (usually for dismissing the modal)
+export default class InfoModal extends React.Component {
+  _onPress = () => {
+    if (this.props.onPress) {
+      this.props.onPress(); //callback when modal is pressed
+    }
+  }
+  render() {
+    return(
+      <Modal animationType={'none'} transparent={true} visible={this.props.modalVisible}>
+        <View style={css.modal_container}>
+          <Text style={css.modal_text_intro}>{this.props.title}</Text>
+          <Text style={css.modal_text}>
+            {this.props.children}
+          </Text>
+
+          <TouchableHighlight underlayColor={'rgba(200,200,200,.5)'} onPress={this._onPress}>
+            <View style={css.modal_button}>
+              <Text style={css.modal_button_text}>{this.props.buttonText}</Text>
+            </View>
+          </TouchableHighlight>
+        </View>
+      </Modal>
+    );
+  }
+}

--- a/app/views/realm.js
+++ b/app/views/realm.js
@@ -1,0 +1,7 @@
+'use strict';
+
+import Realm from 'realm';
+
+var AppSettings = 		require('../AppSettings');
+
+export default new Realm({schema: [AppSettings.DB_SCHEMA], schemaVersion: 2});


### PR DESCRIPTION
@a6wu @c3bryant @jpknoll  I really like this one, I broke out the welcome modal and "welcome banner" into their own components.  The 'WelcomeModal' now talks to realm directly and makes all the decisions about when it should show and writes to realm when it is dismissed.  It then shows a reusable 'InfoModal', which you could then use anywhere else in your app. Nice little self-contained widget.

The welcome banner I abstracted into a generic 'BannerView' which is just a nice touchable image which links to a website.  Then the new 'TopBannerView' is used to decide if the top banner should be show at all.  Currently it is using the same date/time logic to decide if it should show the welcome banner, but this would be a great place to have the top banner get its content from an API or static page so it could change based on the most important campus thing at the moment.

Note: Everything was running well but I couldn't test the last of the changes because it looks like the new mapping library is causing build error -- i get these even on your latest dev branch so it isn't related to this PR (error is in compiling /AIRMapPolygon.o). 