### PR TITLE
Get rid of interaction manager and loaded state

### DIFF
--- a/app/views/Home.js
+++ b/app/views/Home.js
@@ -17,7 +17,6 @@ import {
 	Alert,
 	Navigator,
 	ActivityIndicator,
-	InteractionManager
 } from 'react-native';
 
 import TopBannerView from './banner/TopBannerView';
@@ -65,7 +64,6 @@ var Home = React.createClass({
 			locationPermission: 'undetermined',
 			currentPosition: null,
 			cacheMap: false,
-			loaded:false,
 			refreshing:false,
 			updatedGoogle: true,
 		}
@@ -101,9 +99,6 @@ var Home = React.createClass({
 
 	componentDidMount: function() {
 		logger.ga('View Loaded: Home');
-		InteractionManager.runAfterInteractions(() => {
-			this.setTimeout(() => {this.setState({loaded: true});}, 2000);
-		});
 	},
 
 	componentWillUnmount: function() {


### PR DESCRIPTION
We don't need the interaction manager or the state.loaded variable as it is used nowhere.  Also the way the interaction manager was used here was forcing a re-render for no reason, so the homepage was rendering twice though it doesn't need to.