### PR TITLE
Redux persist

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -43,6 +43,7 @@ import configureStore from './store/configureStore';
 var nowucsandiego = React.createClass({
 
 	getInitialState() {
+		// TODO: hide regular screens until store is hydrated
 		return {
 			store: configureStore({}, () => this.setState({ isLoading: false })),
 			inHome: true,
@@ -102,53 +103,46 @@ var nowucsandiego = React.createClass({
 	},
 
 	render: function () {
-		if (this.state.isLoading) {
-      return null;
-    }
-
+		let navigator;
 		if (general.platformIOS()) {
 			StatusBar.setBarStyle('light-content');
+
+			navigator = (<NavigatorIOS
+				initialRoute={{
+					component: Home,
+					title: AppSettings.APP_NAME,
+					passProps: {
+						isSimulator: this.props.isSimulator
+					},
+					backButtonTitle: 'Back'
+				}}
+				style={{ flex: 1 }}
+				tintColor='#FFFFFF'
+				barTintColor='#006C92'
+				titleTextColor='#FFFFFF'
+				navigationBarHidden={false}
+				translucent={true}
+				ref="navRef"
+			/>);
+		} else {
+			// android we will use NavigationBarWithRouteMapper
+			navigator = (
+				<NavigationBarWithRouteMapper
+					ref="navRef"
+					route={{ id: 'Home', name: 'Home', title: 'now@ucsandiego' }}
+					renderScene={this.renderScene}
+				/>
+			);
 		}
 
-		if (general.platformAndroid()) {
-			return (
-				<Provider store={this.state.store}>
-					<View style={{ flex: 1 }}>
-						<GeoLocationContainer />
-						<NavigationBarWithRouteMapper
-							ref="navRef"
-							route={{ id: 'Home', name: 'Home', title: 'now@ucsandiego' }}
-							renderScene={this.renderScene}
-						/>
-					</View>
-				</Provider>
-			);
-		} else {
-			return (
-				<Provider store={this.state.store}>
-					<View style={{ flex: 1 }}>
-						<GeoLocationContainer />
-						<NavigatorIOS
-							initialRoute={{
-								component: Home,
-								title: AppSettings.APP_NAME,
-								passProps: {
-									isSimulator: this.props.isSimulator
-								},
-								backButtonTitle: 'Back'
-							}}
-							style={{ flex: 1 }}
-							tintColor='#FFFFFF'
-							barTintColor='#006C92'
-							titleTextColor='#FFFFFF'
-							navigationBarHidden={false}
-							translucent={true}
-							ref="navRef"
-						/>
-					</View>
-				</Provider>
-			);
-		}
+		return (
+			<Provider store={this.state.store}>
+				<View style={{ flex: 1 }}>
+					<GeoLocationContainer />
+					{navigator}
+				</View>
+			</Provider>
+		);
 	},
 
 	renderScene: function(route, navigator, index, navState) {

--- a/app/index.js
+++ b/app/index.js
@@ -42,11 +42,11 @@ import configureStore from './store/configureStore';
 
 var nowucsandiego = React.createClass({
 
-	store: configureStore(),
-
 	getInitialState() {
 		return {
+			store: configureStore({}, () => this.setState({ isLoading: false })),
 			inHome: true,
+			isLoading: true,
 		};
 	},
 
@@ -101,7 +101,10 @@ var nowucsandiego = React.createClass({
 		}
 	},
 
-	render: function() {
+	render: function () {
+		if (this.state.isLoading) {
+      return null;
+    }
 
 		if (general.platformIOS()) {
 			StatusBar.setBarStyle('light-content');
@@ -109,7 +112,7 @@ var nowucsandiego = React.createClass({
 
 		if (general.platformAndroid()) {
 			return (
-				<Provider store={this.store}>
+				<Provider store={this.state.store}>
 					<View style={{ flex: 1 }}>
 						<GeoLocationContainer />
 						<NavigationBarWithRouteMapper
@@ -122,7 +125,7 @@ var nowucsandiego = React.createClass({
 			);
 		} else {
 			return (
-				<Provider store={this.store}>
+				<Provider store={this.state.store}>
 					<View style={{ flex: 1 }}>
 						<GeoLocationContainer />
 						<NavigatorIOS

--- a/app/store/configureStore.js
+++ b/app/store/configureStore.js
@@ -1,28 +1,32 @@
+import { AsyncStorage } from 'react-native';
 import { createStore, applyMiddleware } from 'redux';
-
-import rootReducer from '../reducers';
+import { persistStore, autoRehydrate } from 'redux-persist';
 import thunkMiddleware from 'redux-thunk';
 import createLogger from 'redux-logger';
 
+import rootReducer from '../reducers';
+
 const loggerMiddleware = createLogger();
 
-export default function configureStore(initialState) {
- 	const store = createStore(
-    rootReducer,
-    applyMiddleware(
-      thunkMiddleware, // lets us dispatch() functions
-      loggerMiddleware // neat middleware that logs actions
-    ),
-    initialState
-  );
+export default function configureStore(initialState, onComplete: ?() => void) {
+	const store = createStore(
+		rootReducer,
+		applyMiddleware(
+			thunkMiddleware, // lets us dispatch() functions
+			loggerMiddleware // neat middleware that logs actions
+		),
+		autoRehydrate()
+	);
 
 	if (module.hot) {
-    // Enable Webpack hot module replacement for reducers
+		// Enable Webpack hot module replacement for reducers
 		module.hot.accept('../reducers', () => {
 			const nextRootReducer = require('../reducers');
+
 			store.replaceReducer(nextRootReducer);
 		});
 	}
 
+	persistStore(store, { storage: AsyncStorage }, onComplete);
 	return store;
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-timer-mixin": "0.13.3",
     "redux-logger": "2.7.0",
     "redux-thunk": "2.1.0",
+    "redux-persist": "3.5.0",
     "react-native-vector-icons": "2.1.0",
     "react-timer-mixin": "0.13.3"
   },


### PR DESCRIPTION
Just setting up redux persist, which will automatically re-hydrate the redux store on app load.  Also cleaned up the render() method of index.js so it didn't need to create the Provider twice for iOS and android (and instead just switches the nav component).

Tested on iOS and seems to work perfectly, though right now we aren't really saving anything worth persisting, it does work and will remember what cards you setup to view on initial load.

Note: Currently I have a callback to set this.state.IsLoading in the index "nowucsandiego" component so we can later optionally hide the UI until loading is finished (aka while the redux store is re-hydrating).  