### PR TITLE
Simple view for managing card preferences

### DIFF
--- a/app/actions/cards.js
+++ b/app/actions/cards.js
@@ -1,11 +1,29 @@
 
 function hideCard(id) {
-  return {
-    type: 'HIDE_CARD',
-    id: id
-  }
+	return {
+		type: 'HIDE_CARD',
+		id
+	};
+}
+
+function showCard(id) {
+	console.log('show card');
+	return {
+		type: 'SHOW_CARD',
+		id
+	};
+}
+
+function setCardState(card, state) {
+	if (state === true) {
+		return showCard(card);
+	} else {
+		return hideCard(card);
+	}
 }
 
 module.exports = {
-  hideCard
+	hideCard,
+	showCard,
+	setCardState
 };

--- a/app/index.js
+++ b/app/index.js
@@ -34,6 +34,7 @@ import EventListView from './views/events/EventListView';
 import NewsListView from './views/news/NewsListView';
 import DiningListView from './views/dining/DiningListView';
 import FeedbackView from './views/FeedbackView';
+import PreferencesView from './views/preferences/PreferencesView';
 import NearbyMapView from './views/mapsearch/NearbyMapView';
 
 // NAV
@@ -109,6 +110,15 @@ var nowucsandiego = React.createClass({
 		}
 	},
 
+	_handleNavigationRequest() {
+		// TODO: works on iOS
+		this.refs.navRef.push({
+			id: 'PreferencesView',
+			component: PreferencesView,
+			title: 'Preferences'
+		});
+	},
+
 	render: function () {
 		let navigator;
 		if (general.platformIOS()) {
@@ -121,7 +131,9 @@ var nowucsandiego = React.createClass({
 					passProps: {
 						isSimulator: this.props.isSimulator
 					},
-					backButtonTitle: 'Back'
+					backButtonTitle: 'Back',
+					rightButtonTitle: 'Setup',
+					onRightButtonPress: () => this._handleNavigationRequest(),
 				}}
 				style={{ flex: 1 }}
 				tintColor='#FFFFFF'
@@ -155,6 +167,7 @@ var nowucsandiego = React.createClass({
 	renderScene(route, navigator, index, navState) {
 		switch (route.id) {
 		case 'Home': 				return (<Home route={route} navigator={navigator} new_timeout={this.newTimeout} do_timeout={this.doTimeout} />);
+		case 'PreferencesView': return (<PreferencesView route={route} navigator={navigator} />);
 		case 'ShuttleStop': 		return (<ShuttleStop route={route} navigator={navigator} />);
 		case 'SurfReport': 			return (<SurfReport route={route} navigator={navigator} />);
 		case 'DiningListView': 		return (<DiningListView route={route} navigator={navigator} />);

--- a/app/index.js
+++ b/app/index.js
@@ -132,7 +132,7 @@ var nowucsandiego = React.createClass({
 						isSimulator: this.props.isSimulator
 					},
 					backButtonTitle: 'Back',
-					rightButtonTitle: 'Setup',
+					rightButtonSystemIcon: 'organize',
 					onRightButtonPress: () => this._handleNavigationRequest(),
 				}}
 				style={{ flex: 1 }}

--- a/app/reducers/cards.js
+++ b/app/reducers/cards.js
@@ -1,44 +1,44 @@
 // NOTE: AppSettings.XX_CARD_ENABLED is being deprecated to pave the way for more dynamic cards
 
-var initialState = {
-  'weather': true,
-  'shuttle': true,
-  'events': true,
-  'news': true,
-  'dining': true,
-  'mapsearch': true,
-  'quicklinks': true,
-}
+const initialState = {
+	'weather': true,
+	'shuttle': true,
+	'events': true,
+	'news': true,
+	'dining': true,
+	'mapsearch': true,
+	'quicklinks': true,
+};
 
 function cards(state = initialState, action) {
-  switch (action.type) {
-    case 'SHOW_CARD':
-      var newState = {...state};
-      if (newState[action.id])
-        newState[action.id] = true;
-      return newState;
+	switch (action.type) {
+		case 'SHOW_CARD':
+			var newState = {...state};
+			if (!newState[action.id])
+				newState[action.id] = true;
+			return newState;
 
-    case 'HIDE_CARD':
-      var newState = {...state};
-      if (newState[action.id])
-        newState[action.id] = false;
-      return newState;
+		case 'HIDE_CARD':
+			var newState = {...state};
+			if (newState[action.id])
+				newState[action.id] = false;
+			return newState;
 
-    case 'ADD_CARD':
-      var newState = {...state};
-      // check for duplicate, early exit
-      if (newState[action.id])
-        return newState;
+		case 'ADD_CARD':
+			var newState = {...state};
+			// check for duplicate, early exit
+			if (newState[action.id])
+				return newState;
 
-      newState[action.id] = true;
-      return newState;
+			newState[action.id] = true;
+			return newState;
 
-    case 'DELETE_CARD':
-      var newState = {...state};
-      delete newState[action.id];
-      return newState;
-  }
-  return state;
+		case 'DELETE_CARD':
+			var newState = {...state};
+			delete newState[action.id];
+			return newState;
+	}
+	return state;
 }
 
 module.exports = cards

--- a/app/styles/css.js
+++ b/app/styles/css.js
@@ -46,7 +46,7 @@ if (general.platformAndroid()) {
 	navBarMarginTop = 64;
 	navBarTitleMarginTop = 0;
 } else if (general.platformIOS()) {
-	
+
 }
 
 var pixelRatio = PixelRatio.get();
@@ -102,7 +102,7 @@ var css = StyleSheet.create({
 	scroll_main: {},
 	listview_main: { marginTop: 64 },
 	view_default: { paddingHorizontal: round(8 * prm) },
-	
+
 	scroll_default: { alignItems: 'center' },
 
 	// Card Styles
@@ -119,7 +119,7 @@ var css = StyleSheet.create({
 		card_button_container: { flex:1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#F9F9F9', },
 			card_button_text: { flex:1, fontSize: round(20 * prm), alignItems: 'center', textAlign: 'center' },
 	card_text_container: { flexDirection: 'row', justifyContent: 'center', alignItems: 'center', width: maxCardWidth, padding: 8, borderBottomWidth: 1, borderBottomColor: '#DDD' },
-
+	card_content_full_width: { width: maxCardWidth, overflow: 'hidden' },
 
 	// Modal Welcome Message
 	modal_container: { flex: 1, backgroundColor: 'rgba(0, 108, 147, .95)', justifyContent: 'center', padding: round(35 * prm) },
@@ -164,7 +164,7 @@ var css = StyleSheet.create({
 	dl_noresults: { color: '#444', fontSize: round(15 * prm) },
 	dl_market_date: { borderBottomWidth: 1, borderBottomColor: '#EEE', paddingBottom: round(12 * prm), paddingTop: round(6 * prm) },
 		dl_market_date_label: { fontSize: round(22 * prm), color: '#444', textAlign: 'center' },
-	
+
 	dl_market_filters_foodtype: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', marginVertical: round(8 * prm) },
 
 	dl_market_filters_mealtype: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', borderTopWidth: 1, borderTopColor: '#EEE', paddingTop: round(10 * prm) },
@@ -320,7 +320,7 @@ var css = StyleSheet.create({
 
 	// EVENT DETAIL
 	eventdetail_top_container: { flex: 1, flexDirection: 'row', width: windowWidth, padding: 8 },
-		
+
 		eventdetail_image: { width: windowWidth, height: round(windowWidth * .5) },
 		eventdetail_image2: { width: 50, height: 50 },
 		eventdetail_image2_sm: { width: 100, height: 100, borderColor: 'blue', borderWidth: 1 },
@@ -358,7 +358,7 @@ var css = StyleSheet.create({
 	shuttlestop_image: { width: windowWidth, height: round(windowWidth * .533) },
 	shuttlestop_name_container: { height: round(48 * prm), flex: 1, flexDirection: 'row', alignItems: 'center', width: windowWidth, paddingVertical: round(14 * prm), paddingHorizontal: round(20 * prm), backgroundColor: ucsdblue },
 		shuttlestop_name_text: { width: round(windowWidth * .9 - 40), color: '#FFF', fontSize: round(24 * prm), fontWeight: '300' },
-		
+
 		shuttlestop_refresh_container: { position: 'absolute', alignItems: 'center', top: shuttleStopRefreshIconTop, right: 8, width: round(55 * prm) },
 			shuttlestop_refresh: { width: round(26 * prm), height: round(26 * prm) },
 			shuttlestop_refresh_timeago: { fontSize: round(10 * prm), color: '#FFF', marginTop: round(1 * prm), textAlign: 'center', fontWeight: '600', backgroundColor: 'rgba(0,0,0,0)' },
@@ -370,7 +370,7 @@ var css = StyleSheet.create({
 				shuttle_stop_rt_2_label: { textAlign: 'center', fontWeight: '600', fontSize: round(19 * prm), backgroundColor: 'rgba(0,0,0,0)' },
 			shuttle_stop_arrivals_row_route_name: { flex: 2, fontSize: round(17 * prm), color: '#555', paddingLeft: round(10 * prm) },
 			shuttle_stop_arrivals_row_eta_text: { flex: 1, fontSize: round(20 * prm), color: '#333', paddingLeft: round(16 * prm), paddingRight: round(16 * prm) },
-		
+
 		shuttlestop_loading: { width: 48, height: 48, marginHorizontal: 40, marginVertical: round(50 * prm) },
 
 		shuttle_stop_map_container: { margin: 1 },
@@ -403,7 +403,7 @@ var css = StyleSheet.create({
 	// Footer
 	footer: { flex: 1, flexDirection: 'row', paddingBottom: 10 },
 	footer_link: { flex: 15 },
-	
+
 	footer_about: { color: ucsdblue, fontSize: round(16 * prm), textAlign: 'center', padding: 4 },
 	footer_spacer: { flex: 1, color: '#888', padding: 4, fontSize: round(16 * prm), textAlign: 'center' },
 	footer_copyright: { color: ucsdblue, fontSize: round(16 * prm), textAlign: 'center', padding: 4 },

--- a/app/views/NavigationBarWithRouteMapper.js
+++ b/app/views/NavigationBarWithRouteMapper.js
@@ -6,6 +6,7 @@ import {
 	View,
 } from 'react-native';
 
+import Icon from 'react-native-vector-icons/FontAwesome';
 import PreferencesView from './preferences/PreferencesView';
 
 const css = require('../styles/css');
@@ -55,7 +56,7 @@ export default class NavigationBarWithRouteMapper extends React.Component {
 
 								// for the home view, show the preferences button
 								return (
-									<View>
+									<View style={[css.navBarLeftButtonContainer, { paddingBottom: 10 }]}>
 										<TouchableHighlight
 											underlayColor={'rgba(200,200,200,.1)'}
 											onPress={() => {
@@ -66,9 +67,7 @@ export default class NavigationBarWithRouteMapper extends React.Component {
 												});
 											}}
 										>
-											<Text style={css.navBarLeftButton}>
-												Setup
-											</Text>
+											<Icon style={css.navBarLeftButton} name="cog" />
 										</TouchableHighlight>
 									</View>
 								);

--- a/app/views/NavigationBarWithRouteMapper.js
+++ b/app/views/NavigationBarWithRouteMapper.js
@@ -6,21 +6,19 @@ import {
 	View,
 } from 'react-native';
 
-var css = require('../styles/css');
+import PreferencesView from './preferences/PreferencesView';
+
+const css = require('../styles/css');
 
 export default class NavigationBarWithRouteMapper extends React.Component {
-	constructor(props) {
-		super(props);
-	}
-
 	render() {
-		return(
+		return (
 			<Navigator
 				ref="navRef"
 				initialRoute={this.props.route}
 				renderScene={this.props.renderScene}
 				navigationBar={
-					<Navigator.NavigationBar 
+					<Navigator.NavigationBar
 						style={css.navBar}
 						navigationStyles={Navigator.NavigationBar.StylesIOS}
 						routeMapper={{
@@ -51,8 +49,29 @@ export default class NavigationBarWithRouteMapper extends React.Component {
 							},
 
 							RightButton: function(route, navigator, index, navState) {
-								<View>
-								</View>
+								if (route.id !== 'Home') {
+									return null;
+								}
+
+								// for the home view, show the preferences button
+								return (
+									<View>
+										<TouchableHighlight
+											underlayColor={'rgba(200,200,200,.1)'}
+											onPress={() => {
+												navigator.push({
+													id: 'PreferencesView',
+													component: PreferencesView,
+													title: 'Preferences'
+												});
+											}}
+										>
+											<Text style={css.navBarLeftButton}>
+												Setup
+											</Text>
+										</TouchableHighlight>
+									</View>
+								);
 							}
 						}}
 					/>
@@ -60,4 +79,4 @@ export default class NavigationBarWithRouteMapper extends React.Component {
 			/>
 		);
 	}
-};
+}

--- a/app/views/preferences/PreferencesView.js
+++ b/app/views/preferences/PreferencesView.js
@@ -42,8 +42,8 @@ export default class PreferencesView extends Component {
 
 	render() {
 		return (
-			<View style={{ flex: 1, backgroundColor: 'white' }}>
-				<ScrollView>
+			<View style={[css.main_container, css.offwhitebg]}>
+				<ScrollView contentContainerStyle={css.scroll_default}>
 					<Card id="cards" title="Cards">
 						<View style={css.card__container}>
 							<View style={{ flex: 1, flexDirection: 'column' }}>

--- a/app/views/preferences/PreferencesView.js
+++ b/app/views/preferences/PreferencesView.js
@@ -3,6 +3,7 @@ import {
 	View,
 	Text,
 	Switch,
+	StyleSheet,
 	ScrollView
 } from 'react-native';
 import { connect } from 'react-redux';
@@ -23,12 +24,12 @@ export default class PreferencesView extends Component {
 		return Object.keys(this.props.cards).map(key => {
 			const cardActive = this.props.cards[key];
 			return (
-				<View key={key}>
-					<View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-						<View>
+				<View key={key} style={styles.cardContainer}>
+					<View style={styles.spacedRow}>
+						<View style={styles.centerAlign}>
 							<Text>{key}</Text>
 						</View>
-						<View>
+						<View style={styles.centerAlign}>
 							<Switch
 								onValueChange={(value) => this._setCardState(key, value)}
 								value={cardActive}
@@ -45,8 +46,8 @@ export default class PreferencesView extends Component {
 			<View style={[css.main_container, css.offwhitebg]}>
 				<ScrollView contentContainerStyle={css.scroll_default}>
 					<Card id="cards" title="Cards">
-						<View style={css.card__container}>
-							<View style={{ flex: 1, flexDirection: 'column' }}>
+						<View style={css.card_content_full_width}>
+							<View style={styles.column}>
 								{this._renderCards()}
 							</View>
 						</View>
@@ -56,6 +57,25 @@ export default class PreferencesView extends Component {
 		);
 	}
 }
+
+const styles = StyleSheet.create({
+	cardContainer: {
+		padding: 10,
+		borderTopWidth: 1,
+		borderTopColor: '#EEE'
+	},
+	spacedRow: {
+		flexDirection: 'row',
+		justifyContent: 'space-between'
+	},
+	centerAlign: {
+		alignSelf: 'center',
+	},
+	column: {
+		flex: 1,
+		flexDirection: 'column',
+	}
+});
 
 function mapStateToProps(state, props) {
 	return {

--- a/app/views/preferences/PreferencesView.js
+++ b/app/views/preferences/PreferencesView.js
@@ -8,10 +8,9 @@ import {
 import { connect } from 'react-redux';
 
 import { setCardState } from '../../actions';
+import Card from '../card/Card';
 
-// import css from '../styles/css';
-//
-// const logger = require('../util/logger');
+import css from '../../styles/css';
 
 // View for user to manage preferences, including which cards are visible
 export default class PreferencesView extends Component {
@@ -24,8 +23,8 @@ export default class PreferencesView extends Component {
 		return Object.keys(this.props.cards).map(key => {
 			const cardActive = this.props.cards[key];
 			return (
-				<View style={{ flex: 1 }}>
-					<View style={{ flexDirection: 'row', flex: 1, justifyContent: 'space-between' }}>
+				<View>
+					<View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
 						<View>
 							<Text>{key}</Text>
 						</View>
@@ -44,8 +43,14 @@ export default class PreferencesView extends Component {
 	render() {
 		return (
 			<View style={{ flex: 1 }}>
-				<ScrollView style={{ flex: 1 }}>
-					{this._renderCards()}
+				<ScrollView>
+					<Card id="cards" title="Cards">
+						<View style={css.card__container}>
+							<View style={{ flex: 1, flexDirection: 'column' }}>
+								{this._renderCards()}
+							</View>
+						</View>
+					</Card>
 				</ScrollView>
 			</View>
 		);

--- a/app/views/preferences/PreferencesView.js
+++ b/app/views/preferences/PreferencesView.js
@@ -1,0 +1,61 @@
+import React, { Component } from 'react';
+import {
+	View,
+	Text,
+	Switch,
+	ScrollView
+} from 'react-native';
+import { connect } from 'react-redux';
+
+import { setCardState } from '../../actions';
+
+// import css from '../styles/css';
+//
+// const logger = require('../util/logger');
+
+// View for user to manage preferences, including which cards are visible
+export default class PreferencesView extends Component {
+	_setCardState = (card, state) => {
+		this.props.dispatch(setCardState(card, state));
+	}
+
+	// render out all the cards, currently showing or not
+	_renderCards = () => {
+		return Object.keys(this.props.cards).map(key => {
+			const cardActive = this.props.cards[key];
+			return (
+				<View style={{ flex: 1 }}>
+					<View style={{ flexDirection: 'row', flex: 1, justifyContent: 'space-between' }}>
+						<View>
+							<Text>{key}</Text>
+						</View>
+						<View>
+							<Switch
+								onValueChange={(value) => this._setCardState(key, value)}
+								value={cardActive}
+							/>
+						</View>
+					</View>
+				</View>
+			);
+		});
+	}
+
+	render() {
+		return (
+			<View style={{ flex: 1 }}>
+				<ScrollView style={{ flex: 1 }}>
+					{this._renderCards()}
+				</ScrollView>
+			</View>
+		);
+	}
+}
+
+function mapStateToProps(state, props) {
+	return {
+		cards: state.cards,
+	};
+}
+
+module.exports = connect(mapStateToProps)(PreferencesView);

--- a/app/views/preferences/PreferencesView.js
+++ b/app/views/preferences/PreferencesView.js
@@ -23,7 +23,7 @@ export default class PreferencesView extends Component {
 		return Object.keys(this.props.cards).map(key => {
 			const cardActive = this.props.cards[key];
 			return (
-				<View>
+				<View key={key}>
 					<View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
 						<View>
 							<Text>{key}</Text>
@@ -42,7 +42,7 @@ export default class PreferencesView extends Component {
 
 	render() {
 		return (
-			<View style={{ flex: 1 }}>
+			<View style={{ flex: 1, backgroundColor: 'white' }}>
 				<ScrollView>
 					<Card id="cards" title="Cards">
 						<View style={css.card__container}>


### PR DESCRIPTION
Part of #90, this is a screen which the user gets to after clicking the upper-right options button on the home screen.  It just shows all the cards and the user can toggle them on/off and the choice will be persisted.

Later I'd like to clean up the cards store to be able to contain a friendly card name and maybe a description, plus to have the ability to add in new cards that don't yet exist.  But this PR is simple right now so I'll keep it this way.