### PR TITLE
Context Menu for hiding cards

### DIFF
--- a/app/views/Home.js
+++ b/app/views/Home.js
@@ -19,6 +19,7 @@ import {
 	ActivityIndicator,
 } from 'react-native';
 import { connect } from 'react-redux';
+import { MenuContext } from 'react-native-popup-menu';
 
 import TopBannerView from './banner/TopBannerView';
 import WelcomeModal from './WelcomeModal';
@@ -97,6 +98,7 @@ var Home = React.createClass({
 	renderScene(route, navigator, index, navState) {
 		return (
 			<View style={css.main_container}>
+				<MenuContext style={{ flex:1 }}>
 				<ScrollView contentContainerStyle={css.scroll_main} refreshControl={
 					<RefreshControl refreshing={this.state.refreshing} onRefresh={this._handleRefresh} tintColor='#CCC' title='' />
 				}>
@@ -122,6 +124,7 @@ var Home = React.createClass({
 					</View>
 
 				</ScrollView>
+				</MenuContext>
 			</View>
 		);
 	},

--- a/app/views/card/Card.js
+++ b/app/views/card/Card.js
@@ -41,7 +41,7 @@ class Card extends React.Component {
 						<Text>Hide Card</Text>
 					</MenuOption>
 					<MenuOption value={2}>
-						<Text style={{ color: 'red' }}>Two</Text>
+						<Text style={{ color: 'red' }}>Feedback (TODO)</Text>
 					</MenuOption>
 				</MenuOptions>
 			</Menu>

--- a/app/views/card/Card.js
+++ b/app/views/card/Card.js
@@ -38,10 +38,7 @@ class Card extends React.Component {
 				</MenuTrigger>
 				<MenuOptions>
 					<MenuOption onSelect={() => { this.props.dispatch(hideCard(this.props.id)); }}>
-						<Text>Hide Card</Text>
-					</MenuOption>
-					<MenuOption value={2}>
-						<Text style={{ color: 'red' }}>Feedback (TODO)</Text>
+						<Text style={styles.hideOption}>Hide Card</Text>
 					</MenuOption>
 				</MenuOptions>
 			</Menu>
@@ -64,6 +61,10 @@ const styles = StyleSheet.create({
 		justifyContent: 'flex-end',
 		alignItems: 'center',
 		alignSelf: 'stretch',
+	},
+	hideOption: {
+		margin: 10,
+		fontSize: 16
 	},
 	menu_trigger: {
 		padding: 15,

--- a/app/views/card/Card.js
+++ b/app/views/card/Card.js
@@ -1,13 +1,25 @@
 import React from 'react';
 import {
 	View,
+	Text,
+	StyleSheet
 } from 'react-native';
+
+import Menu, {
+	MenuOptions,
+	MenuOption,
+	MenuTrigger,
+} from 'react-native-popup-menu';
+
+import Icon from 'react-native-vector-icons/FontAwesome';
+import { connect } from 'react-redux';
+import { hideCard } from '../../actions/cards';
 
 import CardHeader from './CardHeader';
 
 const css = require('../../styles/css');
 
-export default class Card extends React.Component {
+class Card extends React.Component {
 	setNativeProps(props) {
 		this._card.setNativeProps(props);
 	}
@@ -15,13 +27,47 @@ export default class Card extends React.Component {
 	refresh(refreshType) {
 		return;
 	}
+	_renderMenu = () => {
+		// we can hide the menu if we don't want it, like for non-hideable cards
+		if (this.props.hideMenu) return;
 
+		return (
+			<Menu style={styles.menu} onSelect={value => this.menuOptionSelected(value)}>
+				<MenuTrigger style={styles.menu_trigger}>
+					<Icon size={20} name="ellipsis-v" />
+				</MenuTrigger>
+				<MenuOptions>
+					<MenuOption onSelect={() => { this.props.dispatch(hideCard(this.props.id)); }}>
+						<Text>Hide Card</Text>
+					</MenuOption>
+					<MenuOption value={2}>
+						<Text style={{ color: 'red' }}>Two</Text>
+					</MenuOption>
+				</MenuOptions>
+			</Menu>
+		);
+	}
 	render() {
 		return (
 			<View style={css.card_main} ref={(i) => { this._card = i; }}>
-				<CardHeader id={this.props.id} title={this.props.title} cardRefresh={this.props.cardRefresh} isRefreshing={this.props.isRefreshing} />
+				<CardHeader id={this.props.id} title={this.props.title} menu={this._renderMenu()} />
 				{this.props.children}
 			</View>
 		);
 	}
 }
+
+const styles = StyleSheet.create({
+	menu: {
+		flex: 1,
+		flexDirection: 'row',
+		justifyContent: 'flex-end',
+		alignItems: 'center',
+		alignSelf: 'stretch',
+	},
+	menu_trigger: {
+		padding: 15,
+	}
+});
+
+export default connect()(Card);

--- a/app/views/card/CardHeader.js
+++ b/app/views/card/CardHeader.js
@@ -5,43 +5,12 @@ import {
 	StyleSheet,
 } from 'react-native';
 
-import Menu, {
-	MenuContext,
-	MenuOptions,
-	MenuOption,
-	MenuTrigger,
-} from 'react-native-popup-menu';
-
-import Icon from 'react-native-vector-icons/FontAwesome';
-import { connect } from 'react-redux';
-import { hideCard } from '../../actions/cards';
-
-class CardHeader extends React.Component {
-	_renderMenu = () => {
-		// we can hide the menu if we don't want it, like for non-hideable cards
-		if (this.props.hideMenu) return;
-
-		return (
-			<Menu style={styles.menu} onSelect={value => this.menuOptionSelected(value)}>
-				<MenuTrigger style={styles.menu_trigger}>
-					<Icon size={20} name="ellipsis-v" />
-				</MenuTrigger>
-				<MenuOptions>
-					<MenuOption onSelect={() => { this.props.dispatch(hideCard(this.props.id)); }}>
-						<Text>Hide Card</Text>
-					</MenuOption>
-					<MenuOption value={2}>
-						<Text style={{ color: 'red' }}>Two</Text>
-					</MenuOption>
-				</MenuOptions>
-			</Menu>
-		);
-	}
+export default class CardHeader extends React.Component {
 	render() {
 		return (
 			<View style={styles.container}>
 				<Text style={styles.title}>{this.props.title}</Text>
-				{this._renderMenu()}
+				{this.props.menu}
 			</View>
 		);
 	}
@@ -61,16 +30,4 @@ const styles = StyleSheet.create({
 		margin: 8,
 		color: '#747678'
 	},
-	menu: {
-		flex: 1,
-		flexDirection: 'row',
-		justifyContent: 'flex-end',
-		alignItems: 'center',
-		alignSelf: 'stretch',
-	},
-	menu_trigger: {
-		padding: 15,
-	}
 });
-
-export default connect()(CardHeader);

--- a/app/views/card/CardHeader.js
+++ b/app/views/card/CardHeader.js
@@ -17,37 +17,31 @@ import { connect } from 'react-redux';
 import { hideCard } from '../../actions/cards';
 
 class CardHeader extends React.Component {
-	menuOptionSelected = (index) => {
-		if (index === 1) {
-			// hide card
-		} else if (index === 2) {
-			// feedback
-		}
+	_renderMenu = () => {
+		// we can hide the menu if we don't want it, like for non-hideable cards
+		if (this.props.hideMenu) return;
 
-		alert('selected ' + index);
+		return (
+			<Menu style={styles.menu} onSelect={value => this.menuOptionSelected(value)}>
+				<MenuTrigger style={styles.menu_trigger}>
+					<Icon size={20} name="ellipsis-v" />
+				</MenuTrigger>
+				<MenuOptions>
+					<MenuOption onSelect={() => { this.props.dispatch(hideCard(this.props.id)); }}>
+						<Text>Hide Card</Text>
+					</MenuOption>
+					<MenuOption value={2}>
+						<Text style={{ color: 'red' }}>Two</Text>
+					</MenuOption>
+				</MenuOptions>
+			</Menu>
+		);
 	}
 	render() {
-		const menu = (
-			<MenuContext>
-				<Menu style={styles.menu} onSelect={value => this.menuOptionSelected(value)}>
-					<MenuTrigger style={styles.menu_trigger}>
-						<Icon size={20} name="ellipsis-v" />
-					</MenuTrigger>
-					<MenuOptions>
-						<MenuOption value={1}>
-							<Text>Hide Card</Text>
-						</MenuOption>
-						<MenuOption value={2}>
-							<Text style={{ color: 'red' }}>Two</Text>
-						</MenuOption>
-					</MenuOptions>
-				</Menu>
-			</MenuContext>
-		);
 		return (
 			<View style={styles.container}>
 				<Text style={styles.title}>{this.props.title}</Text>
-				{menu}
+				{this._renderMenu()}
 			</View>
 		);
 	}

--- a/app/views/card/CardHeader.js
+++ b/app/views/card/CardHeader.js
@@ -2,34 +2,47 @@ import React from 'react';
 import {
 	View,
 	Text,
-	Image,
-	ActivityIndicator,
-	TouchableHighlight,
 } from 'react-native';
 
-// import Icon from 'react-native-vector-icons/FontAwesome';
+import Menu, {
+	MenuContext,
+	MenuOptions,
+	MenuOption,
+	MenuTrigger,
+} from 'react-native-popup-menu';
+
+import Icon from 'react-native-vector-icons/FontAwesome';
 
 const css = require('../../styles/css');
 
 export default class CardHeader extends React.Component {
 	render() {
-		let refresh;
-		if (this.props.cardRefresh) {
-			refresh = this.props.isRefreshing ?
-				<ActivityIndicator animating={true} />
-				:
-					<TouchableHighlight underlayColor={'rgba(200,200,200,.1)'} onPress={this.props.cardRefresh}>
-						<Image style={css.shuttle_card_refresh} source={require('../../assets/img/icon_refresh_grey.png')} />
-					</TouchableHighlight>;
-		}
+		const menu = (
+			<MenuContext style={{ flexDirection: 'column', paddingRight: 10 }}>
+				<Menu onSelect={value => alert(`Selected number: ${value}`)}>
+					<MenuTrigger>
+						<View style={{ alignSelf: 'flex-end', paddingTop: 5 }}>
+							<Icon size={20} name="ellipsis-v" />
+						</View>
+					</MenuTrigger>
+					<MenuOptions>
+						<MenuOption value={1} text="One" />
+						<MenuOption value={2}>
+							<Text style={{ color: 'red' }}>Two</Text>
+						</MenuOption>
+					</MenuOptions>
+				</Menu>
+			</MenuContext>
+		);
 		return (
 			<View style={css.card_title_container}>
-				<Text style={css.card_title}>{this.props.title}</Text>
-				<View style={css.shuttle_card_refresh_container}>
-					{refresh}
+				<View>
+					<Text style={css.card_title}>{this.props.title}</Text>
+				</View>
+				<View style={{ flex: 1, justifyContent: 'center' }}>
+					{menu}
 				</View>
 			</View>
 		);
 	}
 }
-// {refresh} <Icon name="caret-down" size={20} color={"#747678"}/>

--- a/app/views/card/CardHeader.js
+++ b/app/views/card/CardHeader.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {
 	View,
 	Text,
+	StyleSheet,
 } from 'react-native';
 
 import Menu, {
@@ -12,21 +13,30 @@ import Menu, {
 } from 'react-native-popup-menu';
 
 import Icon from 'react-native-vector-icons/FontAwesome';
+import { connect } from 'react-redux';
+import { hideCard } from '../../actions/cards';
 
-const css = require('../../styles/css');
+class CardHeader extends React.Component {
+	menuOptionSelected = (index) => {
+		if (index === 1) {
+			// hide card
+		} else if (index === 2) {
+			// feedback
+		}
 
-export default class CardHeader extends React.Component {
+		alert('selected ' + index);
+	}
 	render() {
 		const menu = (
-			<MenuContext style={{ flexDirection: 'column', paddingRight: 10 }}>
-				<Menu onSelect={value => alert(`Selected number: ${value}`)}>
-					<MenuTrigger>
-						<View style={{ alignSelf: 'flex-end', paddingTop: 5 }}>
-							<Icon size={20} name="ellipsis-v" />
-						</View>
+			<MenuContext>
+				<Menu style={styles.menu} onSelect={value => this.menuOptionSelected(value)}>
+					<MenuTrigger style={styles.menu_trigger}>
+						<Icon size={20} name="ellipsis-v" />
 					</MenuTrigger>
 					<MenuOptions>
-						<MenuOption value={1} text="One" />
+						<MenuOption value={1}>
+							<Text>Hide Card</Text>
+						</MenuOption>
 						<MenuOption value={2}>
 							<Text style={{ color: 'red' }}>Two</Text>
 						</MenuOption>
@@ -35,14 +45,38 @@ export default class CardHeader extends React.Component {
 			</MenuContext>
 		);
 		return (
-			<View style={css.card_title_container}>
-				<View>
-					<Text style={css.card_title}>{this.props.title}</Text>
-				</View>
-				<View style={{ flex: 1, justifyContent: 'center' }}>
-					{menu}
-				</View>
+			<View style={styles.container}>
+				<Text style={styles.title}>{this.props.title}</Text>
+				{menu}
 			</View>
 		);
 	}
 }
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		flexDirection: 'row',
+		alignItems: 'center',
+		borderBottomWidth: 1,
+		borderBottomColor: '#DDD',
+		alignSelf: 'stretch',
+	},
+	title: {
+		fontSize: 26,
+		margin: 8,
+		color: '#747678'
+	},
+	menu: {
+		flex: 1,
+		flexDirection: 'row',
+		justifyContent: 'flex-end',
+		alignItems: 'center',
+		alignSelf: 'stretch',
+	},
+	menu_trigger: {
+		padding: 15,
+	}
+});
+
+export default connect()(CardHeader);

--- a/app/views/preferences/PreferencesView.js
+++ b/app/views/preferences/PreferencesView.js
@@ -48,7 +48,7 @@ export default class PreferencesView extends Component {
 		return (
 			<View style={[css.main_container, css.offwhitebg]}>
 				<ScrollView contentContainerStyle={css.scroll_default}>
-					<Card id="cards" title="Cards">
+					<Card id="cards" title="Cards" hideMenu={true}>
 						<View style={css.card_content_full_width}>
 							<View style={css.column}>
 								{this._renderCards()}

--- a/package.json
+++ b/package.json
@@ -16,14 +16,15 @@
     "react-native-google-api-availability-bridge": "1.1.4",
     "react-native-maps": "0.11.0",
     "react-native-permissions": "0.2.5",
+    "react-native-popup-menu": "^0.6.1",
     "react-native-sliding-up-panel": "^1.1.11",
     "react-native-vector-icons": "2.1.0",
     "react-redux": "4.4.5",
     "react-timer-mixin": "0.13.3",
     "redux": "3.6.0",
     "redux-logger": "2.7.0",
-    "redux-thunk": "2.1.0",
-    "redux-persist": "3.5.0"
+    "redux-persist": "3.5.0",
+    "redux-thunk": "2.1.0"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
Adds context menu which will hide cards and can eventually also redirect to feedback link or whatever else.  Most of the work is in the Card.js component because it seemed like something the card should handle.  There is an option `hideMenu` you can send if you want to use the Card component but don't want the menu to show.

Had to add a `MenuContext` to the main container, which is invisible and just means that there can be only one menu on the screen at once.  That seemed like a good idea.  Check out the image, let me know if you have any questions.

![image](https://cloud.githubusercontent.com/assets/202753/21165055/ad9330ac-c151-11e6-80df-7a1352b1ac4c.png)

