### PR TITLE
User account display UI

### DIFF
--- a/app/AppSettings.js
+++ b/app/AppSettings.js
@@ -33,7 +33,7 @@ module.exports = {
 	QUICKLINKS_API_TTL: 		86400,
 
 	USER_LOGIN: {
-		ENABLED: true,
+		ENABLED: false,
 		METHOD: 'openid',
 	}
 };

--- a/app/AppSettings.js
+++ b/app/AppSettings.js
@@ -32,4 +32,8 @@ module.exports = {
 	DINING_API_TTL: 			60,
 	QUICKLINKS_API_TTL: 		86400,
 
+	USER_LOGIN: {
+		ENABLED: true,
+		METHOD: 'openid',
+	}
 };

--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -1,5 +1,8 @@
-const cardsActions = require('./cards')
+import cardsActions from './cards';
+import userActions from './user';
+
 
 module.exports = {
-  ...cardsActions
+	...cardsActions,
+	...userActions,
 };

--- a/app/actions/user.js
+++ b/app/actions/user.js
@@ -1,0 +1,23 @@
+// User actions related to authentication
+export const LOGGED_IN = 'LOGGED_IN';
+export const LOGGING_IN = 'LOGGING_IN';
+export const LOGGED_OUT = 'LOGGED_OUT';
+
+export function userLoggedIn(userInfo) {
+	return {
+		type: LOGGED_IN,
+		data: userInfo,
+	};
+}
+
+export function userLoggingIn() {
+	return {
+		type: LOGGING_IN
+	};
+}
+
+export function userLoggedOut() {
+	return {
+		type: LOGGED_OUT,
+	};
+}

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -2,8 +2,10 @@ import { combineReducers } from 'redux';
 
 import cardsReducer from './cards';
 import locationReducer from './location';
+import userReducer from './user';
 
 module.exports = combineReducers({
 	cards: cardsReducer,
-	location: locationReducer
+	location: locationReducer,
+	user: userReducer,
 });

--- a/app/reducers/user.js
+++ b/app/reducers/user.js
@@ -1,0 +1,43 @@
+import { LOGGED_IN, LOGGING_IN, LOGGED_OUT } from '../actions/user';
+
+export type State = {
+	isLoggedIn: boolean;
+	isLoggingIn: boolean;
+	auth: ?Object;
+	profile: ?Object;
+};
+
+const initialState = {
+	isLoggedIn: false,
+	isLoggingIn: false,
+	auth: null,
+	profile: null,
+};
+
+function user(state: State = initialState, action): State {
+	if (action.type === LOGGED_IN) {
+		const { auth, profile } = action.data;
+		return {
+			...state,
+			isLoggedIn: true,
+			isLoggingIn: false,
+			auth,
+			profile,
+		};
+	}
+	if (action.type === LOGGING_IN) {
+		return {
+			...state,
+			isLoggingIn: true,
+		};
+	}
+	if (action.type === LOGGED_OUT) {
+		return {
+			...state,
+			...initialState,
+		};
+	}
+	return state;
+}
+
+module.exports = user;

--- a/app/store/configureStore.js
+++ b/app/store/configureStore.js
@@ -27,6 +27,6 @@ export default function configureStore(initialState, onComplete: ?() => void) {
 		});
 	}
 
-	persistStore(store, { storage: AsyncStorage, whitelist: [ 'cards' ] }, onComplete);
+	persistStore(store, { storage: AsyncStorage, whitelist: ['cards', 'user'] }, onComplete);
 	return store;
 }

--- a/app/views/preferences/CardPreferences.js
+++ b/app/views/preferences/CardPreferences.js
@@ -1,0 +1,64 @@
+import React, { Component } from 'react';
+import {
+	View,
+	Text,
+	Switch,
+} from 'react-native';
+
+import { connect } from 'react-redux';
+
+import { setCardState } from '../../actions';
+import Card from '../card/Card';
+import css from '../../styles/css';
+
+// View for user to manage preferences, including which cards are visible
+export default class CardPreferences extends Component {
+	_setCardState = (card, state) => {
+		this.props.dispatch(setCardState(card, state));
+	}
+
+	// render out all the cards, currently showing or not
+	_renderCards = () => {
+		return Object.keys(this.props.cards).map(key => {
+
+			const cardActive = this.props.cards[key].active;
+			const cardName = this.props.cards[key].name;
+
+			return (
+				<View key={key} style={css.preferencesContainer}>
+					<View style={css.spacedRow}>
+						<View style={css.centerAlign}>
+							<Text style={css.prefCardTitle}>{cardName}</Text>
+						</View>
+						<View style={css.centerAlign}>
+							<Switch
+								onValueChange={(value) => { this._setCardState(key, value) }}
+								value={cardActive}
+							/>
+						</View>
+					</View>
+				</View>
+			);
+		});
+	}
+
+	render() {
+		return (
+			<Card id="cards" title="Cards" hideMenu={true}>
+				<View style={css.card_content_full_width}>
+					<View style={css.column}>
+						{this._renderCards()}
+					</View>
+				</View>
+			</Card>
+		);
+	}
+}
+
+function mapStateToProps(state, props) {
+	return {
+		cards: state.cards,
+	};
+}
+
+module.exports = connect(mapStateToProps)(CardPreferences);

--- a/app/views/preferences/PreferencesView.js
+++ b/app/views/preferences/PreferencesView.js
@@ -8,9 +8,10 @@ import {
 } from 'react-native';
 import { connect } from 'react-redux';
 
+import UserAccount from './UserAccount';
+
 import { setCardState } from '../../actions';
 import Card from '../card/Card';
-
 import css from '../../styles/css';
 
 // View for user to manage preferences, including which cards are visible
@@ -48,6 +49,7 @@ export default class PreferencesView extends Component {
 		return (
 			<View style={[css.main_container, css.offwhitebg]}>
 				<ScrollView contentContainerStyle={css.scroll_default}>
+					<UserAccount />
 					<Card id="cards" title="Cards" hideMenu={true}>
 						<View style={css.card_content_full_width}>
 							<View style={css.column}>

--- a/app/views/preferences/PreferencesView.js
+++ b/app/views/preferences/PreferencesView.js
@@ -1,72 +1,23 @@
 import React, { Component } from 'react';
 import {
 	View,
-	Text,
-	Switch,
-	StyleSheet,
 	ScrollView
 } from 'react-native';
-import { connect } from 'react-redux';
 
 import UserAccount from './UserAccount';
-
-import { setCardState } from '../../actions';
-import Card from '../card/Card';
+import CardPreferences from './CardPreferences';
 import css from '../../styles/css';
 
 // View for user to manage preferences, including which cards are visible
 export default class PreferencesView extends Component {
-	_setCardState = (card, state) => {
-		this.props.dispatch(setCardState(card, state));
-	}
-
-	// render out all the cards, currently showing or not
-	_renderCards = () => {
-		return Object.keys(this.props.cards).map(key => {
-
-			const cardActive = this.props.cards[key].active;
-			const cardName = this.props.cards[key].name;
-
-			return (
-				<View key={key} style={css.preferencesContainer}>
-					<View style={css.spacedRow}>
-						<View style={css.centerAlign}>
-							<Text style={css.prefCardTitle}>{cardName}</Text>
-						</View>
-						<View style={css.centerAlign}>
-							<Switch
-								onValueChange={(value) => { this._setCardState(key, value) }}
-								value={cardActive}
-							/>
-						</View>
-					</View>
-				</View>
-			);
-		});
-	}
-
 	render() {
 		return (
 			<View style={[css.main_container, css.offwhitebg]}>
 				<ScrollView contentContainerStyle={css.scroll_default}>
 					<UserAccount />
-					<Card id="cards" title="Cards" hideMenu={true}>
-						<View style={css.card_content_full_width}>
-							<View style={css.column}>
-								{this._renderCards()}
-							</View>
-						</View>
-					</Card>
+					<CardPreferences />
 				</ScrollView>
 			</View>
 		);
 	}
 }
-
-function mapStateToProps(state, props) {
-	return {
-		cards: state.cards,
-	};
-}
-
-module.exports = connect(mapStateToProps)(PreferencesView);

--- a/app/views/preferences/UserAccount.js
+++ b/app/views/preferences/UserAccount.js
@@ -29,7 +29,7 @@ export default class UserAccount extends Component {
 	_renderAccountInfo = () => {
 		// show the account info of logged in user, or not logged in
 		if (this.props.user.isLoggedIn) {
-			return this._renderAccountContainer('Cal Doval');
+			return this._renderAccountContainer('User Info TBD');
 		} else {
 			return this._renderAccountContainer('Tap to Log In');
 		}

--- a/app/views/preferences/UserAccount.js
+++ b/app/views/preferences/UserAccount.js
@@ -1,0 +1,60 @@
+import React, { Component } from 'react';
+import {
+	View,
+	Text,
+	TouchableOpacity,
+} from 'react-native';
+
+import { connect } from 'react-redux';
+import Icon from 'react-native-vector-icons/FontAwesome';
+
+import Settings from '../../AppSettings';
+import Card from '../card/Card';
+import css from '../../styles/css';
+
+// View for user to manage account, sign-in or out
+export default class UserAccount extends Component {
+	_renderAccountContainer = (mainText) => {
+		return (
+			<TouchableOpacity style={css.spacedRow} onPress={() => {}}>
+				<View style={css.centerAlign}>
+					<Text style={css.prefCardTitle}>{mainText}</Text>
+				</View>
+				<View style={css.centerAlign}>
+					<Icon name="user" />
+				</View>
+			</TouchableOpacity>
+		);
+	}
+	_renderAccountInfo = () => {
+		// show the account info of logged in user, or not logged in
+		if (this.props.user.isLoggedIn) {
+			return this._renderAccountContainer('Cal Doval');
+		} else {
+			return this._renderAccountContainer('Tap to Log In');
+		}
+	}
+	render() {
+		if (Settings.USER_LOGIN.ENABLED === false) return null;
+
+		return (
+			<Card id="user" title="Account" hideMenu={true}>
+				<View style={css.card_content_full_width}>
+					<View style={css.column}>
+						<View style={css.preferencesContainer}>
+							{this._renderAccountInfo()}
+						</View>
+					</View>
+				</View>
+			</Card>
+		);
+	}
+}
+
+function mapStateToProps(state, props) {
+	return {
+		user: state.user,
+	};
+}
+
+module.exports = connect(mapStateToProps)(UserAccount);


### PR DESCRIPTION
Note: this is just UI -- on the preferences page the user would be able to see a 'tap to login' button and their name if they are already logged in.  Those changes would persist in the new 'user' Redux store.  Also there is an appSettings USER_LOGIN.ENABLED which is set to false, so until we turn that to true nothing new will happen.

I wanted to get this merged as a start / proof of concept before I started making changes to actually implement auth.  Let me know what you think

![image](https://cloud.githubusercontent.com/assets/202753/21869527/db6a28ec-d80c-11e6-88c2-7dadb3f9eb0a.png)
