### PR TITLE
Implementation of user login using OpenID

### DIFF
--- a/app/AppSettings.js
+++ b/app/AppSettings.js
@@ -35,5 +35,12 @@ module.exports = {
 	USER_LOGIN: {
 		ENABLED: true,
 		METHOD: 'openid',
+		OPTIONS: {
+			CLIENT_ID: 'nowimplicit',
+			AUTH_URL: 'https://auth-dev.ucdavis.edu/identity/connect/authorize',
+			USER_INFO_URL: 'https://auth-dev.ucdavis.edu/identity/connect/userinfo',
+			REDIRECT_URL: 'nowmobile://cb',
+			STATE: 'M9NGbE6bnUV18FflfVeZ2U0j94'
+		}
 	}
 };

--- a/app/AppSettings.js
+++ b/app/AppSettings.js
@@ -33,7 +33,7 @@ module.exports = {
 	QUICKLINKS_API_TTL: 		86400,
 
 	USER_LOGIN: {
-		ENABLED: false,
+		ENABLED: true,
 		METHOD: 'openid',
 	}
 };

--- a/app/AppSettings.js
+++ b/app/AppSettings.js
@@ -33,7 +33,7 @@ module.exports = {
 	QUICKLINKS_API_TTL: 		86400,
 
 	USER_LOGIN: {
-		ENABLED: true,
+		ENABLED: false,
 		METHOD: 'openid',
 		OPTIONS: {
 			CLIENT_ID: 'nowimplicit',

--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -1,6 +1,5 @@
 import cardsActions from './cards';
-import userActions from './user';
-
+import * as userActions from './user'; // ES6 way
 
 module.exports = {
 	...cardsActions,

--- a/app/actions/user.js
+++ b/app/actions/user.js
@@ -1,18 +1,11 @@
 // User actions related to authentication
 export const LOGGED_IN = 'LOGGED_IN';
-export const LOGGING_IN = 'LOGGING_IN';
 export const LOGGED_OUT = 'LOGGED_OUT';
 
 export function userLoggedIn(userInfo) {
 	return {
 		type: LOGGED_IN,
 		data: userInfo,
-	};
-}
-
-export function userLoggingIn() {
-	return {
-		type: LOGGING_IN
 	};
 }
 

--- a/app/reducers/user.js
+++ b/app/reducers/user.js
@@ -1,15 +1,13 @@
-import { LOGGED_IN, LOGGING_IN, LOGGED_OUT } from '../actions/user';
+import { LOGGED_IN, LOGGED_OUT } from '../actions/user';
 
 export type State = {
 	isLoggedIn: boolean;
-	isLoggingIn: boolean;
 	auth: ?Object;
 	profile: ?Object;
 };
 
 const initialState = {
 	isLoggedIn: false,
-	isLoggingIn: false,
 	auth: null,
 	profile: null,
 };
@@ -20,15 +18,8 @@ function user(state: State = initialState, action): State {
 		return {
 			...state,
 			isLoggedIn: true,
-			isLoggingIn: false,
 			auth,
 			profile,
-		};
-	}
-	if (action.type === LOGGING_IN) {
-		return {
-			...state,
-			isLoggingIn: true,
 		};
 	}
 	if (action.type === LOGGED_OUT) {

--- a/app/services/authenticationService.js
+++ b/app/services/authenticationService.js
@@ -1,0 +1,57 @@
+import Settings from '../AppSettings';
+
+// OIDC authentication provider
+class OpenAuthentication {
+	createAuthenticationUrl = () => {
+		const openIdSettings = Settings.USER_LOGIN.OPTIONS;
+		const authUrl = [
+			`${openIdSettings.AUTH_URL}`,
+			'?response_type=id_token+token',
+			`&client_id=${openIdSettings.CLIENT_ID}`,
+			`&redirect_uri=${openIdSettings.REDIRECT_URL}`,
+			'&scope=openid+profile+email',
+			`&state=${openIdSettings.STATE}`,
+			`&nonce=${Math.random().toString(36).slice(2)}`
+		].join('');
+
+		return authUrl;
+	}
+	handleAuthenticationCallback = (event) => {
+		const openIdSettings = Settings.USER_LOGIN.OPTIONS;
+
+		// only handle callback URLs, in case we deep link for other things
+		if (event.url.startsWith(openIdSettings.REDIRECT_URL)) {
+			// get access_token, POST to userinfo endpoint to get back user info
+			const accessRegex = event.url.match(/access_token=([^&]*)/);
+			const stateRegex = event.url.match(/state=([^&]*)/);
+
+			if (accessRegex && stateRegex) {
+				// first, verify the state regex is what we expected
+				if (stateRegex[1] !== openIdSettings.STATE) {
+					return; // just don't handle the event, though maybe log error?
+				}
+
+				const access_token = accessRegex[1]; // just get the value from the match group
+
+				return fetch(openIdSettings.USER_INFO_URL, {
+					method: 'POST',
+					headers: {
+						'Authorization': `Bearer ${access_token}`,
+					},
+				})
+				.then(result => result.json())
+				.then(userInfo => Promise.resolve(userInfo));
+			}
+		}
+
+		return Promise.reject({ message: 'could not validate login' });
+	}
+}
+
+export default function getAuthenticationService() {
+	if (Settings.USER_LOGIN.METHOD === 'openid') {
+		return new OpenAuthentication();
+	}
+
+	return null;
+}

--- a/app/views/preferences/UserAccount.js
+++ b/app/views/preferences/UserAccount.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import {
 	View,
 	Text,
+	Linking,
 	TouchableOpacity,
 } from 'react-native';
 
@@ -14,9 +15,24 @@ import css from '../../styles/css';
 
 // View for user to manage account, sign-in or out
 export default class UserAccount extends Component {
+	_performUserAuthAction = () => {
+		// TODO: for now, assume they want to log in
+		// TODO: create nonce
+		const clientId = 'nowimplicit';
+		const authUrl = [
+			'https://auth-dev.ucdavis.edu/identity/connect/authorize',
+			'?response_type=id_token token',
+			// '&response_mode=form_post',
+			`&client_id=${clientId}`,
+			'&redirect_uri=nowmobile://cb',
+			'&nonce=1234'
+		].join('');
+
+		Linking.openURL(authUrl).catch(err => console.error('An error occurred', err));
+	}
 	_renderAccountContainer = (mainText) => {
 		return (
-			<TouchableOpacity style={css.spacedRow} onPress={() => {}}>
+			<TouchableOpacity style={css.spacedRow} onPress={this._performUserAuthAction}>
 				<View style={css.centerAlign}>
 					<Text style={css.prefCardTitle}>{mainText}</Text>
 				</View>

--- a/app/views/preferences/UserAccount.js
+++ b/app/views/preferences/UserAccount.js
@@ -15,16 +15,40 @@ import css from '../../styles/css';
 
 // View for user to manage account, sign-in or out
 export default class UserAccount extends Component {
+	componentDidMount() {
+		console.log('listener added');
+		Linking.addEventListener('url', this._handleOpenURL);
+	}
+	componentWillUnmount() {
+		console.log('unmounted');
+		Linking.removeEventListener('url', this._handleOpenURL);
+	}
+	_handleOpenURL(event) {
+		console.log('OPENING URL');
+		console.log(event.url);
+
+		// TODO: get access_token, POST to userinfo endpoint to get back user info
+		if (event.url.startsWith('nowmobile://cb')) {
+			// only handle callback URLs, in case we deep link for other things
+			const accessRegex = event.url.match(/access_token=([^&]*)/);
+
+			if (accessRegex) {
+				const access_token = accessRegex[1]; // just get the value from the match group
+
+				// fetch('https://auth-dev.ucdavis.edu/identity/connect/userinfo')
+			}
+		}
+	}
 	_performUserAuthAction = () => {
 		// TODO: for now, assume they want to log in
-		// TODO: create nonce
+		// TODO: nonce I don't think is needed, but we might want state to verify origination
 		const clientId = 'nowimplicit';
 		const authUrl = [
 			'https://auth-dev.ucdavis.edu/identity/connect/authorize',
-			'?response_type=id_token token',
-			// '&response_mode=form_post',
+			'?response_type=id_token+token',
 			`&client_id=${clientId}`,
 			'&redirect_uri=nowmobile://cb',
+			'&scope=openid+profile+email',
 			'&nonce=1234'
 		].join('');
 

--- a/ios/nowucsandiego.xcodeproj/project.pbxproj
+++ b/ios/nowucsandiego.xcodeproj/project.pbxproj
@@ -830,6 +830,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../node_modules/react-native/Libraries/LinkingIOS",
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/realm/src/**",
 					"$(SRCROOT)/../node_modules/react-native-google-analytics-bridge/ios/RCTGoogleAnalyticsBridge/**",
@@ -861,9 +862,11 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEAD_CODE_STRIPPING = NO;
+				DEVELOPMENT_TEAM = WL46WDAA95;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../node_modules/react-native/Libraries/LinkingIOS",
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/realm/src/**",
 					"$(SRCROOT)/../node_modules/react-native-google-analytics-bridge/ios/RCTGoogleAnalyticsBridge/**",

--- a/ios/nowucsandiego/AppDelegate.m
+++ b/ios/nowucsandiego/AppDelegate.m
@@ -13,8 +13,16 @@
 #import "RCTLog.h"
 #import "RCTUtils.h"
 #import "RCTRootView.h"
+#import "RCTLinkingManager.h"
 
 @implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
+  sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
+{
+  return [RCTLinkingManager application:application openURL:url
+                      sourceApplication:sourceApplication annotation:annotation];
+}
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {

--- a/ios/nowucsandiego/Info.plist
+++ b/ios/nowucsandiego/Info.plist
@@ -20,6 +20,19 @@
 	<string>2.4.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>edu.ucsd.ucsdnow</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>nowmobile</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>7</string>
 	<key>CodePushDeploymentKey</key>


### PR DESCRIPTION
Probably still a work in progress since we'll want to cleanup to allow of multiple auth methods (right now it's openID only) and add in some user error messages, but this is fully functional and should work with standard openID providers.  It handles login, logout, and stores the user info in Redux persisted across sessions.  I had to link the LinkingIOS library so the app can now handle inbound links/urls, as instructed in http://facebook.github.io/react-native/releases/0.39/docs/linking.html.  Note because of this I've only tested in iOS.  

 